### PR TITLE
Fix usb.c so EUSCIA0_IRQHandler is called fix USCI_UART_ConfigV1 type and add Interrupt_enableMaster() in main()

### DIFF
--- a/src/main.c
+++ b/src/main.c
@@ -47,6 +47,8 @@ int main(void)
     // Add custom chars to CGRAM
     createCustomChars();
 
+    MAP_Interrupt_enableMaster();           /* enable processing all interrupts */
+
     while (1);
 }
 
@@ -89,7 +91,11 @@ void usbCallbackFxn(uint8_t charReceived)
     {
         USB_sendBuffer("\n", 1);
 
-        if(strcmp(rxBuffer, "HAPPY") == 0)
+        if (*rxBuffer < 'A' || 'Z' < *rxBuffer)
+        {
+            LCD_writeString ((uint8_t*)rxBuffer, rxPtr);
+        }
+        else if(strcmp(rxBuffer, "HAPPY") == 0)
         {
             LCD_writeChar(HAPPYFACE_ADDR);
         }
@@ -164,10 +170,6 @@ void usbCallbackFxn(uint8_t charReceived)
         else if(strcmp(rxBuffer, "BACKLIGHTOFF") == 0)
         {
             LCD_backlightOff();
-        }
-        else
-        {
-            LCD_writeString((uint8_t*)rxBuffer, rxPtr);
         }
 
         // Clear buffer

--- a/src/usb.c
+++ b/src/usb.c
@@ -17,12 +17,13 @@
 #define RX_INTERRUPT            EUSCI_A_UART_RECEIVE_INTERRUPT
 #define TX_INTERRUPT            EUSCI_A_UART_TRANSMIT_INTERRUPT
 #define USB_UART_INT            INT_EUSCIA0
+#define USB_intHandler          EUSCIA0_IRQHandler
 
 /***************************
  * UART Configuration based on TI Tool:
  * http://software-dl.ti.com/msp430/msp430_public_sw/mcu/msp430/MSP430BaudRateConverter/index.html
  ***************************/
-const eUSCI_UART_Config usbUARTConfig =
+const eUSCI_UART_ConfigV1 usbUARTConfig =
 {
     EUSCI_A_UART_CLOCKSOURCE_SMCLK,                 // SMCLK Clock Source
     19,                                             // BRDIV = 19


### PR DESCRIPTION
Here are a couple of small changes to update the code so it will work with the current version of CCS. A define was required to provide a proper UART interrupt handles, the UART config type needed updating and master interrupt needed enabling in main(). A slight change to the `if ... else if ...` ordering was changed in `usbCallbackFxn()` so the repeated calls to `strdmp()` are avoided unless input begins with a capital letter.